### PR TITLE
This commit addresses user feedback on sensor naming and forecast pre…

### DIFF
--- a/custom_components/meteolux/translations/en.json
+++ b/custom_components/meteolux/translations/en.json
@@ -23,6 +23,24 @@
             "temp_min": {
                 "name": "ML - Min Temperature"
             },
+            "morning_temp_low": {
+                "name": "ML - Morning Low Temperature"
+            },
+            "morning_temp_high": {
+                "name": "ML - Morning High Temperature"
+            },
+            "afternoon_temp_low": {
+                "name": "ML - Afternoon Low Temperature"
+            },
+            "afternoon_temp_high": {
+                "name": "ML - Afternoon High Temperature"
+            },
+            "evening_temp_low": {
+                "name": "ML - Evening Low Temperature"
+            },
+            "evening_temp_high": {
+                "name": "ML - Evening High Temperature"
+            },
             "morning_precipitation": {
                 "name": "ML - Morning Precipitation"
             },

--- a/custom_components/meteolux/weather.py
+++ b/custom_components/meteolux/weather.py
@@ -42,7 +42,7 @@ class MeteoluxWeather(CoordinatorEntity[MeteoluxDataUpdateCoordinator], WeatherE
     _attr_native_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_native_precipitation_unit = UnitOfPrecipitationDepth.MILLIMETERS
     _attr_native_wind_speed_unit = UnitOfSpeed.KILOMETERS_PER_HOUR
-    _attr_supported_features = WeatherEntityFeature.FORECAST_DAILY
+    _attr_supported_features = WeatherEntityFeature.FORECAST_HOURLY
 
     def __init__(self, coordinator: MeteoluxDataUpdateCoordinator) -> None:
         """Initialize the weather entity."""
@@ -101,8 +101,8 @@ class MeteoluxWeather(CoordinatorEntity[MeteoluxDataUpdateCoordinator], WeatherE
             return None
         return current_forecast.wind_direction
 
-    async def async_forecast_daily(self) -> list[Forecast] | None:
-        """Return the daily forecast."""
+    async def async_forecast_hourly(self) -> list[Forecast] | None:
+        """Return the hourly forecast."""
         if not self.coordinator.data:
             return None
 


### PR DESCRIPTION
…sentation.

- **Fix (Sensor Names):** A bug causing several temperature forecast sensors to have the same name has been fixed. Missing entries were added to the translation file to ensure each sensor has a unique, descriptive name (e.g., 'ML - Morning Low Temperature').

- **Feat (Forecast Display):** The main weather entity has been updated to present the forecast as 'hourly' rather than 'daily'. This better reflects the intra-day (morning, afternoon, evening) nature of the data provided by the MeteoLux API and improves its presentation in the Home Assistant UI.