### PR TITLE
Fix config flow loading error

### DIFF
--- a/custom_components/meteolux/config_flow.py
+++ b/custom_components/meteolux/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.data_entry_flow import FlowResult
 from .const import DOMAIN
 
 
-class MeteoluxConfigFlow(ConfigFlow, domain=DOMAIN):
+class MeteoluxConfigFlow(ConfigFlow):
     """Handle a config flow for MeteoLux."""
 
     VERSION = 1


### PR DESCRIPTION
The `domain` keyword argument is no longer supported in the `ConfigFlow` class definition. This was causing a `TypeError` when Home Assistant tried to load the config flow, resulting in a 500 Internal Server Error.

This change removes the `domain` argument from the class definition, which resolves the issue and allows the config flow to be loaded correctly.