### PR TITLE
Fix invalid handler error in config flow

### DIFF
--- a/custom_components/meteolux/config_flow.py
+++ b/custom_components/meteolux/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.data_entry_flow import FlowResult
 from .const import DOMAIN
 
 
-class MeteoluxConfigFlow(ConfigFlow, domain=DOMAIN):
+class MeteoluxConfigFlow(ConfigFlow):
     """Handle a config flow for MeteoLux."""
 
     VERSION = 1


### PR DESCRIPTION
This commit removes the `domain=DOMAIN` argument from the `MeteoluxConfigFlow` class definition.

After fixing a previous `ImportError`, a new error "Invalid handler specified" was revealed. This indicates that for the target version of Home Assistant, the `domain` should not be passed as a keyword argument to the `ConfigFlow` class.

This change, combined with the previous diagnostic fixes (removing the unused binary_sensor platform and fixing the coordinator import), should now allow the integration to be configured successfully.