### PR TITLE
Fix incorrect FlowResult import path in config_flow.py

### DIFF
--- a/custom_components/meteolux/config_flow.py
+++ b/custom_components/meteolux/config_flow.py
@@ -5,9 +5,8 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow
+from homeassistant.config_entries import ConfigFlow, FlowResult
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
-from homeassistant.data_entry_flow import FlowResult
 
 from .const import DOMAIN
 


### PR DESCRIPTION
This commit corrects the import path for `FlowResult`, which was still pointing to a deprecated location. This was causing `config_flow.py` to fail on load, resulting in the "Invalid handler specified" error.

This fix is the final step after a long diagnostic process, which also included:
- Removing the unused binary_sensor platform and its dependency.
- Fixing a separate ImportError in the data coordinator.
- Removing the deprecated `domain` argument from the ConfigFlow class.

With this final import fix, the integration should now load correctly.