### PR TITLE
feat: Allow several days ahead forecast

### DIFF
--- a/custom_components/meteolux/config_flow.py
+++ b/custom_components/meteolux/config_flow.py
@@ -1,12 +1,32 @@
 """Config flow for MeteoLux."""
 from __future__ import annotations
-
+import logging
 from typing import Any
 
-from homeassistant import config_entries
-from homeassistant.data_entry_flow import FlowResult
+import voluptuous as vol
 
-from .const import DOMAIN
+from homeassistant import config_entries
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.schema_config_entry_flow import (
+    SchemaCommonFlowHandler,
+    SchemaFlowFormStep,
+    SchemaOptionsFlowHandler,
+)
+from .const import (
+    DOMAIN,
+    CONF_FORECAST_DAYS,
+    DEFAULT_FORECAST_DAYS,
+    FORECAST_DAYS_RANGE
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+OPTIONS_SCHEMA = vol.Schema({
+    vol.Required(CONF_FORECAST_DAYS, default=DEFAULT_FORECAST_DAYS): vol.In(FORECAST_DAYS_RANGE)
+})
+
+CONFIG_SCHEMA = vol.Schema({vol.Required("dummy", default=True): bool})
 
 
 class MeteoluxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -22,6 +42,39 @@ class MeteoluxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="single_instance_allowed")
 
         if user_input is not None:
-            return self.async_create_entry(title="MeteoLux", data={})
+            return self.async_create_entry(title="MeteoLux", data={}, options={CONF_FORECAST_DAYS: DEFAULT_FORECAST_DAYS})
 
         return self.async_show_form(step_id="user")
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return MeteoluxOptionsFlowHandler(config_entry)
+
+
+class MeteoluxOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options."""
+
+    def __init__(self, config_entry):
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_FORECAST_DAYS,
+                        default=self.config_entry.options.get(
+                            CONF_FORECAST_DAYS, DEFAULT_FORECAST_DAYS
+                        ),
+                    ): vol.In(FORECAST_DAYS_RANGE),
+                }
+            ),
+        )

--- a/custom_components/meteolux/const.py
+++ b/custom_components/meteolux/const.py
@@ -1,7 +1,12 @@
 """Constants for the MeteoLux integration."""
 from datetime import time
+from typing import Final
 
 DOMAIN = "meteolux"
+
+CONF_FORECAST_DAYS: Final = "forecast_days"
+DEFAULT_FORECAST_DAYS: Final = 7
+FORECAST_DAYS_RANGE: Final = range(1, 8)
 
 # Old CSV data source (kept as fallback)
 DATA_URL = "https://data.public.lu/en/datasets/r/c05ecc27-aa44-4c96-bece-6149783e1758"

--- a/custom_components/meteolux/manifest.json
+++ b/custom_components/meteolux/manifest.json
@@ -6,6 +6,7 @@
   "codeowners": ["@koosoli"],
   "version": "2.0.1",
   "config_flow": true,
+  "options_flow": true,
   "iot_class": "cloud_polling",
   "requirements": []
 }

--- a/custom_components/meteolux/translations/en.json
+++ b/custom_components/meteolux/translations/en.json
@@ -9,6 +9,16 @@
         "abort": {
             "single_instance_allowed": "Only a single instance of MeteoLux is allowed."
         }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "MeteoLux Options",
+        "data": {
+          "forecast_days": "Number of forecast days"
+        }
+      }
+    }
     },
     "entity": {
         "weather": {

--- a/custom_components/meteolux/weather.py
+++ b/custom_components/meteolux/weather.py
@@ -18,7 +18,13 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from .api import Forecast as MeteoluxForecast, DailyForecast, HourlyForecast
-from .const import CONDITION_MAP, DOMAIN, FORECAST_TIMES
+from .const import (
+    CONDITION_MAP,
+    DOMAIN,
+    FORECAST_TIMES,
+    CONF_FORECAST_DAYS,
+    DEFAULT_FORECAST_DAYS,
+)
 from .coordinator import MeteoluxDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -186,7 +192,10 @@ class MeteoluxWeather(CoordinatorEntity[MeteoluxDataUpdateCoordinator], WeatherE
         # Use new API data if available
         if self.coordinator.data.daily_forecasts:
             forecasts = []
-            for daily_forecast in self.coordinator.data.daily_forecasts[:7]:  # Max 7 days
+            forecast_days = self.coordinator.config_entry.options.get(
+                CONF_FORECAST_DAYS, DEFAULT_FORECAST_DAYS
+            )
+            for daily_forecast in self.coordinator.data.daily_forecasts[:forecast_days]:
                 forecast = Forecast(
                     datetime=daily_forecast.datetime.isoformat(),
                     condition=_map_condition(daily_forecast.condition),


### PR DESCRIPTION
This change implements a configurable number of forecast days for the MeteoLux integration.

- Adds an options flow to allow users to select the number of forecast days (1-7).
- The weather entity now displays the configured number of forecast days.
- Adds necessary constants, translations, and updates the manifest.