### PR TITLE
hotfix: Remove invalid options_flow key from manifest.json

### DIFF
--- a/custom_components/meteolux/manifest.json
+++ b/custom_components/meteolux/manifest.json
@@ -6,7 +6,6 @@
   "codeowners": ["@koosoli"],
   "version": "2.0.1",
   "config_flow": true,
-  "options_flow": true,
   "iot_class": "cloud_polling",
   "requirements": []
 }


### PR DESCRIPTION
This change removes the `options_flow: true` key from the manifest.json file. This key is not valid and was causing the 'Invalid handler specified' error when trying to load the integration's configuration flow.

The options flow is correctly enabled by the `async_get_options_flow` method in the `ConfigFlow` class, so this key is unnecessary and harmful.