### PR TITLE
hotfix: Clean up config_flow.py to resolve loading error

### DIFF
--- a/custom_components/meteolux/config_flow.py
+++ b/custom_components/meteolux/config_flow.py
@@ -26,13 +26,6 @@ from homeassistant.helpers.selectors import SelectSelector, SelectSelectorConfig
 
 _LOGGER = logging.getLogger(__name__)
 
-OPTIONS_SCHEMA = vol.Schema({
-    vol.Required(CONF_FORECAST_DAYS, default=DEFAULT_FORECAST_DAYS): vol.In(FORECAST_DAYS_RANGE),
-    vol.Required(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): SelectSelector(SelectSelectorConfig(options=LANGUAGES, mode=SelectSelectorMode.DROPDOWN)),
-})
-
-CONFIG_SCHEMA = vol.Schema({vol.Required("dummy", default=True): bool})
-
 
 class MeteoluxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for MeteoLux."""


### PR DESCRIPTION
This change removes unused global schema definitions from `config_flow.py`. These unused variables were likely causing an import-time issue that resulted in the "Invalid handler specified" error.

This cleanup should resolve the config flow loading problem and make the code cleaner and less prone to such issues in the future.