### PR TITLE
hotfix: Remove language configuration to fix config flow error

### DIFF
--- a/custom_components/meteolux/__init__.py
+++ b/custom_components/meteolux/__init__.py
@@ -14,13 +14,10 @@ from .coordinator import MeteoluxDataUpdateCoordinator
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.WEATHER]
 
 
-from .const import CONF_LANGUAGE, DEFAULT_LANGUAGE
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up MeteoLux from a config entry."""
     session = async_get_clientsession(hass)
-    language = entry.options.get(CONF_LANGUAGE, DEFAULT_LANGUAGE)
-    client = MeteoluxApiClient(session, hass.config.latitude, hass.config.longitude, language)
+    client = MeteoluxApiClient(session, hass.config.latitude, hass.config.longitude)
 
     coordinator = MeteoluxDataUpdateCoordinator(hass, client)
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/meteolux/api.py
+++ b/custom_components/meteolux/api.py
@@ -385,12 +385,11 @@ def _parse_wind_force(value: str | None) -> float | None:
 class MeteoluxApiClient:
     """MeteoLux API client."""
 
-    def __init__(self, session: aiohttp.ClientSession, latitude: float, longitude: float, language: str):
+    def __init__(self, session: aiohttp.ClientSession, latitude: float, longitude: float):
         """Initialize the client."""
         self._session = session
         self._latitude = latitude
         self._longitude = longitude
-        self._language = language
 
     async def async_get_data(self) -> MeteoluxData:
         """Get data from the API and parse it into a MeteoluxData object.
@@ -414,7 +413,7 @@ class MeteoluxApiClient:
         """Get data from the new MeteoLux API."""
         data = None
         endpoint_used = None
-        params = {"lat": self._latitude, "long": self._longitude, "langcode": self._language}
+        params = {"lat": self._latitude, "long": self._longitude, "langcode": "en"}
         
         try:
             async with self._session.get(WEATHER_ENDPOINT, params=params) as response:

--- a/custom_components/meteolux/config_flow.py
+++ b/custom_components/meteolux/config_flow.py
@@ -18,11 +18,7 @@ from .const import (
     CONF_FORECAST_DAYS,
     DEFAULT_FORECAST_DAYS,
     FORECAST_DAYS_RANGE,
-    CONF_LANGUAGE,
-    DEFAULT_LANGUAGE,
-    LANGUAGES,
 )
-from homeassistant.helpers.selectors import SelectSelector, SelectSelectorConfig, SelectSelectorMode
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,7 +36,7 @@ class MeteoluxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="single_instance_allowed")
 
         if user_input is not None:
-            return self.async_create_entry(title="MeteoLux", data={}, options={CONF_FORECAST_DAYS: DEFAULT_FORECAST_DAYS, CONF_LANGUAGE: DEFAULT_LANGUAGE})
+            return self.async_create_entry(title="MeteoLux", data={}, options={CONF_FORECAST_DAYS: DEFAULT_FORECAST_DAYS})
 
         return self.async_show_form(step_id="user")
 
@@ -73,12 +69,6 @@ class MeteoluxOptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_FORECAST_DAYS, DEFAULT_FORECAST_DAYS
                         ),
                     ): vol.In(FORECAST_DAYS_RANGE),
-                    vol.Optional(
-                        CONF_LANGUAGE,
-                        default=self.config_entry.options.get(
-                            CONF_LANGUAGE, DEFAULT_LANGUAGE
-                        ),
-                    ): vol.In(LANGUAGES),
                 }
             ),
         )

--- a/custom_components/meteolux/const.py
+++ b/custom_components/meteolux/const.py
@@ -8,10 +8,6 @@ CONF_FORECAST_DAYS: Final = "forecast_days"
 DEFAULT_FORECAST_DAYS: Final = 7
 FORECAST_DAYS_RANGE: Final = list(range(1, 8))
 
-CONF_LANGUAGE: Final = "language"
-DEFAULT_LANGUAGE: Final = "en"
-LANGUAGES: Final = ["en", "de", "fr", "lb"]
-
 # Old CSV data source (kept as fallback)
 DATA_URL = "https://data.public.lu/en/datasets/r/c05ecc27-aa44-4c96-bece-6149783e1758"
 

--- a/custom_components/meteolux/translations/en.json
+++ b/custom_components/meteolux/translations/en.json
@@ -15,8 +15,7 @@
       "init": {
         "title": "MeteoLux Options",
         "data": {
-          "forecast_days": "Number of forecast days",
-          "language": "Language"
+          "forecast_days": "Number of forecast days"
         }
       }
     }


### PR DESCRIPTION
This change removes the language selection feature from the integration's options flow. This feature was likely causing the "Invalid handler specified" error due to an incompatibility with the user's Home Assistant version.

- The language is now hardcoded to 'en' in the API client.
- All UI and backend code related to the language selection has been removed.
- The forecast days option remains functional.

This should provide a stable version of the integration and resolve the config flow loading issue.