### PR TITLE
Fix Meteolux weather entity and forecast days

### DIFF
--- a/custom_components/meteolux/api.py
+++ b/custom_components/meteolux/api.py
@@ -135,12 +135,18 @@ class MeteoluxData:
             # Extract weather condition from various possible formats
             weather_condition = None
             if isinstance(current_data.get("weather"), dict):
-                weather_condition = current_data["weather"].get("description")
+                weather_condition = (
+                    current_data["weather"].get("condition")
+                    or current_data["weather"].get("description")
+                )
             elif isinstance(current_data.get("weather"), str):
                 weather_condition = current_data["weather"]
             elif "condition" in current_data:
                 weather_condition = current_data["condition"]
             
+            if not weather_condition and isinstance(current_data.get("icon"), dict):
+                weather_condition = current_data["icon"].get("name")
+
             # Extract wind data
             wind_speed = None
             wind_direction = None

--- a/custom_components/meteolux/const.py
+++ b/custom_components/meteolux/const.py
@@ -5,8 +5,8 @@ from typing import Final
 DOMAIN = "meteolux"
 
 CONF_FORECAST_DAYS: Final = "forecast_days"
-DEFAULT_FORECAST_DAYS: Final = 7
-FORECAST_DAYS_RANGE: Final = list(range(1, 8))
+DEFAULT_FORECAST_DAYS: Final = 5
+FORECAST_DAYS_RANGE: Final = list(range(1, 6))
 
 # Old CSV data source (kept as fallback)
 DATA_URL = "https://data.public.lu/en/datasets/r/c05ecc27-aa44-4c96-bece-6149783e1758"

--- a/custom_components/meteolux/sensor.py
+++ b/custom_components/meteolux/sensor.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api import MeteoluxData
-from .const import DOMAIN
+from .const import DOMAIN, DEFAULT_FORECAST_DAYS
 from .coordinator import MeteoluxDataUpdateCoordinator
 
 
@@ -154,15 +154,23 @@ async def async_setup_entry(
 
     entities = [MeteoluxSensor(coordinator, description) for description in SENSORS]
 
-    forecast_days = entry.options.get("forecast_days", 7)
-    for day in range(forecast_days):
+    configured_forecast_days = entry.options.get(
+        "forecast_days", DEFAULT_FORECAST_DAYS
+    )
+
+    available_forecasts = 0
+    if coordinator.data and coordinator.data.daily_forecasts:
+        available_forecasts = len(coordinator.data.daily_forecasts)
+
+    # Create sensors only for the available forecast days, up to the configured limit
+    for day in range(min(configured_forecast_days, available_forecasts)):
         for description in FORECAST_SENSORS:
             entities.append(
                 MeteoluxDaySensor(
                     coordinator,
                     day,
                     MeteoluxSensorEntityDescription(
-                        key=f"day_{day}_{description.key}",
+                        key=f"day_{day+1}_{description.key}",
                         translation_key=description.translation_key,
                         native_unit_of_measurement=description.native_unit_of_measurement,
                         device_class=description.device_class,


### PR DESCRIPTION
This commit addresses two issues with the Meteolux integration:

1. The main weather entity was showing an "unknown" state. This was due to the API response for the current weather condition not being parsed correctly. The parsing logic in `api.py` has been made more robust to handle different possible keys for the weather condition in the API response.

2. The integration was creating forecast sensors for 7 days, but the Meteolux API only provides data for 5 days. This resulted in sensors for days 6 and 7 showing an "unavailable" state. The default number of forecast days has been changed to 5 in `const.py`. The sensor creation logic in `sensor.py` has also been updated to only create sensors for the number of days of forecast data actually available from the API.