### PR TITLE
feat(sensor): Add vigilance sensor for weather warnings

### DIFF
--- a/custom_components/meteolux/api.py
+++ b/custom_components/meteolux/api.py
@@ -64,6 +64,19 @@ class CurrentWeather:
 
 
 @dataclass
+class Vigilance:
+    """Class for holding vigilance data."""
+
+    datetime_start: datetime | None
+    datetime_end: datetime | None
+    level: int | None
+    type: int | None
+    group: int | None
+    region: str | None
+    description: str | None
+
+
+@dataclass
 class MeteoluxData:
     """Class for holding MeteoLux data."""
 
@@ -74,6 +87,7 @@ class MeteoluxData:
     current_weather: CurrentWeather | None = None
     daily_forecasts: list[DailyForecast] | None = None
     hourly_forecasts: list[HourlyForecast] | None = None
+    vigilances: list[Vigilance] | None = None
     data_source: str | None = None
     api_endpoint_used: str | None = None
 
@@ -90,6 +104,7 @@ class MeteoluxData:
             "temp_max": _parse_float(raw_data.get("temp_max")),
             "forecasts": {},
             "data_source": "CSV",
+            "vigilances": None,
         }
 
         for i in range(1, 4):  # For morning, afternoon, evening
@@ -282,6 +297,44 @@ class MeteoluxData:
                     cloud_coverage=hour_data.get("cloud_coverage") or hour_data.get("clouds"),
                 ))
 
+        # Parse vigilances
+        vigilances = []
+        vigilance_data = api_data.get("vigilances", [])
+        if vigilance_data:
+            for vigilance_item in vigilance_data:
+                if not vigilance_item:
+                    continue
+
+                start_time = None
+                if "datetimeStart" in vigilance_item:
+                    try:
+                        start_time = datetime.fromisoformat(
+                            str(vigilance_item["datetimeStart"]).replace("Z", "+00:00")
+                        )
+                    except (ValueError, TypeError):
+                        pass
+
+                end_time = None
+                if "datetimeEnd" in vigilance_item:
+                    try:
+                        end_time = datetime.fromisoformat(
+                            str(vigilance_item["datetimeEnd"]).replace("Z", "+00:00")
+                        )
+                    except (ValueError, TypeError):
+                        pass
+
+                vigilances.append(
+                    Vigilance(
+                        datetime_start=start_time,
+                        datetime_end=end_time,
+                        level=vigilance_item.get("level"),
+                        type=vigilance_item.get("type"),
+                        group=vigilance_item.get("group"),
+                        region=vigilance_item.get("region"),
+                        description=vigilance_item.get("description"),
+                    )
+                )
+
         # Determine temperature range from daily forecasts if available
         temp_min = None
         temp_max = None
@@ -303,6 +356,7 @@ class MeteoluxData:
             current_weather=current_weather,
             daily_forecasts=daily_forecasts,
             hourly_forecasts=hourly_forecasts,
+            vigilances=vigilances,
             data_source="API",
             api_endpoint_used=endpoint_used,
         )

--- a/custom_components/meteolux/sensor.py
+++ b/custom_components/meteolux/sensor.py
@@ -31,7 +31,50 @@ class MeteoluxSensorEntityDescription(SensorEntityDescription):
     """Describes a MeteoLux sensor entity."""
 
     value_fn: Callable[..., float | str | None] = None
+    attributes_fn: Callable[[MeteoluxData], dict[str, Any]] | None = None
     available_fn: Callable[[MeteoluxData], bool] = lambda data: True
+
+
+def _get_vigilance_level(data: MeteoluxData) -> str | int:
+    """Get the highest vigilance level."""
+    if not data.vigilances:
+        return "none"
+
+    highest_level = 0
+    for v in data.vigilances:
+        if v.level and v.level > highest_level:
+            highest_level = v.level
+
+    return highest_level if highest_level > 0 else "none"
+
+
+def _get_vigilance_attributes(data: MeteoluxData) -> dict[str, Any]:
+    """Get the attributes for the vigilance sensor."""
+    if not data.vigilances:
+        return {}
+
+    highest_vigilance = None
+    highest_level = 0
+    for v in data.vigilances:
+        if v.level and v.level > highest_level:
+            highest_level = v.level
+            highest_vigilance = v
+
+    if not highest_vigilance:
+        return {}
+
+    return {
+        "description": highest_vigilance.description,
+        "start_time": highest_vigilance.datetime_start.isoformat()
+        if highest_vigilance.datetime_start
+        else None,
+        "end_time": highest_vigilance.datetime_end.isoformat()
+        if highest_vigilance.datetime_end
+        else None,
+        "type": highest_vigilance.type,
+        "region": highest_vigilance.region,
+        "active_warnings": len(data.vigilances),
+    }
 
 
 def get_forecast_value_fn(period: str, key: str) -> Callable[[MeteoluxData], Any]:
@@ -87,6 +130,14 @@ SENSORS: tuple[MeteoluxSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         value_fn=lambda data: data.temp_min,
+    ),
+    MeteoluxSensorEntityDescription(
+        key="vigilance_level",
+        translation_key="vigilance_level",
+        icon="mdi:alert-outline",
+        value_fn=_get_vigilance_level,
+        attributes_fn=_get_vigilance_attributes,
+        available_fn=lambda data: data.vigilances is not None,
     ),
 )
 
@@ -209,6 +260,13 @@ class MeteoluxSensor(CoordinatorEntity[MeteoluxDataUpdateCoordinator], SensorEnt
         """Return the state of the sensor."""
         if self.coordinator.data:
             return self.entity_description.value_fn(self.coordinator.data)
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return the state attributes."""
+        if self.coordinator.data and self.entity_description.attributes_fn:
+            return self.entity_description.attributes_fn(self.coordinator.data)
         return None
 
     @property

--- a/custom_components/meteolux/translations/en.json
+++ b/custom_components/meteolux/translations/en.json
@@ -48,6 +48,9 @@
             "temp_min": {
                 "name": "Min Temperature"
             },
+            "vigilance_level": {
+                "name": "Vigilance Level"
+            },
             "day_temp_max": {
                 "name": "Day {day} Max Temperature"
             },


### PR DESCRIPTION
This commit introduces a new sensor to display weather vigilance information from the MeteoLux API.

- A new `Vigilance` dataclass has been added to `api.py` to model the vigilance data.
- The `MeteoluxData` class is updated to include a list of vigilance events.
- The API client now parses the `vigilances` array from the weather endpoint.
- A new "Vigilance Level" sensor is added, which displays the highest active vigilance level as its state.
- The sensor includes attributes for the warning description, start/end times, type, and region of the highest-level warning.
- English translations for the new sensor have been added.

The integration already uses the Home Assistant instance's latitude and longitude for location-specific data, so no changes were needed for that part of the user's request.