### PR TITLE
fix(parser): Improve parsing for forecast data and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ The integration fetches data from the official MeteoLux API and provides both cu
 
 ## Features
 
-- **Current Weather**: Real-time weather conditions including temperature, humidity, pressure, wind speed/direction, and visibility
-- **Hourly Forecast**: Up to 48 hours of detailed weather forecasts
-- **Daily Forecast**: Up to 7 days of daily weather forecasts  
-- **Comprehensive Weather Data**: Precipitation, cloud coverage, and detailed weather descriptions
-- **Automatic Fallback**: Falls back to CSV data source if the main API is unavailable
+- **Current Weather**: Real-time weather conditions including temperature, humidity, pressure, wind speed/direction, and visibility.
+- **Hourly Forecast**: Up to 48 hours of detailed hourly weather forecasts.
+- **Daily Forecast**: Up to 5 days of configurable daily weather forecasts.
+- **Weather Warnings**: A dedicated sensor for vigilance/weather warnings.
+- **Comprehensive Weather Data**: Precipitation, cloud coverage, and detailed weather descriptions.
+- **Automatic Fallback**: Falls back to a legacy CSV data source if the main API is unavailable.
 
 ## Installation
 
@@ -30,27 +31,31 @@ The integration fetches data from the official MeteoLux API and provides both cu
 1.  Go to **Settings** -> **Devices & Services**.
 2.  Click the **+ Add Integration** button.
 3.  Search for "MeteoLux" and click on it.
-4.  The integration will be added and a weather entity and several sensors will be created. No further configuration is needed.
+4.  The integration will be added and a weather entity and several sensors will be created.
+5.  To change the number of forecast days, go to the integration's card on the Devices & Services page and click "Configure".
 
 ## Provided Entities
 
 ### Weather
 
--   `weather.meteolux`: A weather entity that provides current conditions and forecasts for Luxembourg.
-    - Supports both hourly and daily forecasts
-    - Provides current temperature, humidity, pressure, wind data, and visibility
-    - Automatically maps weather conditions to Home Assistant icons
+-   `weather.meteolux_weather`: A weather entity that provides current conditions and forecasts.
+    - Supports both hourly and daily forecasts (configurable from 1 to 5 days).
+    - Provides current temperature, humidity, pressure, wind data, and visibility.
+    - Automatically maps weather conditions to Home Assistant icons.
 
 ### Sensors
 
-The integration provides the following sensors:
+The integration provides a variety of sensors, including:
 
--   `sensor.meteolux_max_temperature`: The maximum temperature for the day.
--   `sensor.meteolux_min_temperature`: The minimum temperature for the day.
--   `sensor.meteolux_morning_precipitation`: The forecasted precipitation for the morning.
--   `sensor.meteolux_afternoon_precipitation`: The forecasted precipitation for the afternoon.
--   `sensor.meteolux_evening_precipitation`: The forecasted precipitation for the evening.
--   And many more sensors for different time periods covering temperature, precipitation, wind conditions, and weather descriptions.
+-   `sensor.meteolux_vigilance_level`: Displays the current highest weather warning level. Attributes contain details of the warning.
+-   `sensor.meteolux_max_temperature`: The maximum temperature forecast for the current day.
+-   `sensor.meteolux_min_temperature`: The minimum temperature forecast for the current day.
+-   **Per-day forecast sensors**: For each configured forecast day, sensors are created for:
+    -   Max/Min Temperature
+    -   Condition
+    -   Precipitation
+    -   Wind Speed, Gusts, and Direction
+-   **Status sensors**: `sensor.meteolux_last_update`, `sensor.meteolux_data_source`, etc.
 
 ## Data Sources
 

--- a/custom_components/meteolux/api.py
+++ b/custom_components/meteolux/api.py
@@ -227,16 +227,16 @@ class MeteoluxData:
                 wind_gusts = None
                 wind_data = day_data.get("wind", {})
                 if isinstance(wind_data, dict):
-                    wind_speed = _parse_float_from_string(wind_data.get("speed"))
+                    wind_speed = _parse_api_value(wind_data.get("speed"))
                     wind_direction = wind_data.get("direction")
-                    wind_gusts = _parse_float_from_string(wind_data.get("gusts"))
+                    wind_gusts = _parse_api_value(wind_data.get("gusts"))
                 
                 daily_forecasts.append(DailyForecast(
                     datetime=day_datetime,
                     condition=weather_condition,
                     temperature_max=temp_max,
                     temperature_min=temp_min,
-                    precipitation=_parse_float_from_string(day_data.get("rain")),
+                    precipitation=_parse_api_value(day_data.get("rain")),
                     wind_speed=wind_speed,
                     wind_direction=wind_direction,
                     wind_gusts=wind_gusts,
@@ -280,15 +280,15 @@ class MeteoluxData:
                 wind_gusts = None
                 wind_data = hour_data.get("wind", {})
                 if isinstance(wind_data, dict):
-                    wind_speed = _parse_float_from_string(wind_data.get("speed"))
+                    wind_speed = _parse_api_value(wind_data.get("speed"))
                     wind_direction = wind_data.get("direction")
-                    wind_gusts = _parse_float_from_string(wind_data.get("gusts"))
+                    wind_gusts = _parse_api_value(wind_data.get("gusts"))
                 
                 hourly_forecasts.append(HourlyForecast(
                     datetime=hour_datetime,
                     condition=weather_condition,
                     temperature=temp,
-                    precipitation=_parse_float_from_string(hour_data.get("rain")),
+                    precipitation=_parse_api_value(hour_data.get("rain")),
                     wind_speed=wind_speed,
                     wind_direction=wind_direction,
                     wind_gusts=wind_gusts,
@@ -426,6 +426,28 @@ def _parse_float_from_string(value: str | None) -> float | None:
         return float(value.split(" ")[0].replace(",", "."))
     except (ValueError, TypeError):
         return None
+
+
+def _parse_api_value(value: str | None) -> float | None:
+    """Parse a value from the API, which can be a single number or a range."""
+    if value is None or value == "":
+        return None
+
+    # Treat value as a string to be safe
+    str_value = str(value)
+
+    # First, try to parse it as a simple float
+    try:
+        return float(str_value.split(" ")[0].replace(",", "."))
+    except (ValueError, TypeError):
+        # If that fails, it might be a range (e.g., "5-10")
+        try:
+            cleaned_value = str_value.split(" ")[0]
+            _, high = _parse_range(cleaned_value)
+            return high
+        except (ValueError, TypeError, IndexError):
+            _LOGGER.warning("Could not parse value: %s", value)
+            return None
 
 
 def _parse_precipitation(value: str | None) -> float | None:


### PR DESCRIPTION
This commit addresses several issues:
- Fixes sensors showing "unknown" by introducing a more robust parsing function (`_parse_api_value`) that can handle both single values and ranges (e.g., "10-20 km/h"). This is applied to precipitation, wind speed, and wind gust data for both daily and hourly forecasts.
- Updates the `README.md` to be more accurate. It now correctly states the forecast is for up to 5 days (configurable) instead of 7.
- The "Provided Entities" section in the README has been rewritten to reflect the current sensors, including the recently added vigilance sensor.
- Added instructions to the README on how to configure the number of forecast days.