### PR TITLE
fix: Implement vigilance sensor and fix parsing and forecast logic

### DIFF
--- a/custom_components/meteolux/weather.py
+++ b/custom_components/meteolux/weather.py
@@ -194,12 +194,21 @@ class MeteoluxWeather(CoordinatorEntity[MeteoluxDataUpdateCoordinator], WeatherE
 
     async def async_forecast_hourly(self) -> list[Forecast] | None:
         """Return the hourly forecast."""
+        _LOGGER.debug("Fetching hourly forecast")
         if not self.coordinator.data or not self.coordinator.data.hourly_forecasts:
+            _LOGGER.debug("No hourly forecast data available in coordinator")
             return None
+
+        _LOGGER.debug(
+            "Processing %s hourly forecasts from coordinator",
+            len(self.coordinator.data.hourly_forecasts),
+        )
 
         # Use new API data if available
         forecasts = []
-        for hourly_forecast in self.coordinator.data.hourly_forecasts[:48]:  # Max 48 hours
+        for i, hourly_forecast in enumerate(
+            self.coordinator.data.hourly_forecasts[:48]
+        ):  # Max 48 hours
             if not hourly_forecast or not hourly_forecast.datetime:
                 continue
             forecast = Forecast(
@@ -213,5 +222,11 @@ class MeteoluxWeather(CoordinatorEntity[MeteoluxDataUpdateCoordinator], WeatherE
                 native_pressure=hourly_forecast.pressure,
                 cloud_coverage=hourly_forecast.cloud_coverage,
             )
+            # Log the first processed forecast for debugging
+            if i == 0:
+                _LOGGER.debug("First processed hourly forecast item: %s", forecast)
+
             forecasts.append(forecast)
+
+        _LOGGER.debug("Returning %s processed hourly forecasts", len(forecasts))
         return forecasts


### PR DESCRIPTION
This commit provides a comprehensive update to the MeteoLux integration, addressing several user-reported issues.

- feat(sensor): Adds a new "Vigilance Level" sensor. This sensor displays the highest active weather warning level from the MeteoLux API and includes detailed information about the warning in its attributes.

- fix(parser): Fixes an issue where many forecast sensors would show an "unknown" state. A new robust parsing function has been implemented in `api.py` to handle API values that can be either a single number or a range (e.g., "10-20"). This is applied to precipitation, wind speed, and wind gust data for both daily and hourly forecasts.

- fix(weather): Resolves a bug that prevented the hourly forecast from being displayed in the Home Assistant UI. The forecast methods in `weather.py` have been refactored to correctly handle the new API data and the legacy CSV fallback, ensuring the hourly forecast data is returned correctly.

- docs(readme): Updates the `README.md` to be accurate and more informative. It now reflects the new vigilance sensor, the correct 5-day forecast limit, and provides a clearer overview of all provided entities and features.