### PR TITLE
Revert: Revert high/low temperature feature to fix regression

### DIFF
--- a/custom_components/meteolux/weather.py
+++ b/custom_components/meteolux/weather.py
@@ -70,11 +70,7 @@ class MeteoluxWeather(CoordinatorEntity[MeteoluxDataUpdateCoordinator], WeatherE
     _attr_native_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_native_precipitation_unit = UnitOfPrecipitationDepth.MILLIMETERS
     _attr_native_wind_speed_unit = UnitOfSpeed.KILOMETERS_PER_HOUR
-    _attr_supported_features = (
-        WeatherEntityFeature.FORECAST_HOURLY
-        | WeatherEntityFeature.FORECAST_DAILY
-        | WeatherEntityFeature.FORECAST_TEMP_HIGH_LOW
-    )
+    _attr_supported_features = WeatherEntityFeature.FORECAST_HOURLY | WeatherEntityFeature.FORECAST_DAILY
 
     def __init__(self, coordinator: MeteoluxDataUpdateCoordinator) -> None:
         """Initialize the weather entity."""
@@ -140,20 +136,6 @@ class MeteoluxWeather(CoordinatorEntity[MeteoluxDataUpdateCoordinator], WeatherE
         if not self.coordinator.data or not self.coordinator.data.current_weather:
             return None
         return self.coordinator.data.current_weather.wind_direction
-
-    @property
-    def native_forecast_temp_high(self) -> float | None:
-        """Return the high temperature of the current day."""
-        if not self.coordinator.data:
-            return None
-        return self.coordinator.data.temp_max
-
-    @property
-    def native_forecast_temp_low(self) -> float | None:
-        """Return the low temperature of the current day."""
-        if not self.coordinator.data:
-            return None
-        return self.coordinator.data.temp_min
 
     async def async_forecast_daily(self) -> list[Forecast] | None:
         """Return the daily forecast."""


### PR DESCRIPTION
This reverts the previous commit that added the high/low temperature feature to the weather entity. The feature was causing a regression that prevented the integration from being added.

This change restores the integration to a working state, including the original fix for the stale data issue. The high/low temperature feature will be re-implemented in a subsequent, more careful update.